### PR TITLE
Central Authentication Service

### DIFF
--- a/defaultcfg.py
+++ b/defaultcfg.py
@@ -28,6 +28,14 @@ EMAIL_DOMAIN='localdomain'
 REDIS_HOST='localhost'
 REDIS_PORT=6379
 
+#USER auth mode
+#can be 'cas' or 'ldap'
+USER_AUTH='cas'
+
+#CAS configuration
+CAS_SERVER_URL='https://domain.invalid/'
+CAS_SERVICE_URL='https://cortex.invalid/cas'
+
 ## MySQL
 MYSQL_HOST='localhost'
 MYSQL_USER='cortex'
@@ -57,7 +65,7 @@ LDAP_BIND_PW        = ''
 LDAP_ADMIN_GROUP    = "CN=groupname,OU=localhost,DC=localdomain"
 
 # Infoblox server
-INFOBLOX_HOST = "" 
+INFOBLOX_HOST = ""
 INFOBLOX_USER = ""
 INFOBLOX_PASS = ""
 

--- a/lib/user.py
+++ b/lib/user.py
@@ -23,9 +23,8 @@ def login_required(f):
 	@wraps(f)
 	def decorated_function(*args, **kwargs):
 		if not is_logged_in():
-			flash('You must login first!', 'alert-danger')
-			args = url_encode(request.args)
-			return redirect(url_for('login', next=request.script_root + request.path + "?" + args))
+			session['next'] = request.url
+			return redirect(url_for('root'))
 		return f(*args, **kwargs)
 	return decorated_function
 
@@ -50,6 +49,7 @@ def clear_session():
 	session.pop('logged_in', None)
 	session.pop('username', None)
 	session.pop('id', None)
+	session.pop('cas_ticket', None)
 
 
 ################################################################################
@@ -66,7 +66,7 @@ def logon_ok(username):
 	app.logger.info('User "' + session['username'] + '" logged in from "' + request.remote_addr + '" using ' + request.user_agent.string)
 
 	# Determine if "next" variable is set (the URL to be sent to)
-	next = request.form.get('next', default=None)
+	next = session.pop('next', None)
 
 	if next == None:
 		return redirect(url_for('dashboard'))

--- a/lib/user.py
+++ b/lib/user.py
@@ -54,7 +54,7 @@ def clear_session():
 
 ################################################################################
 
-def logon_ok(username): 
+def logon_ok(username):
 	"""This function is called post-logon or post TOTP logon to complete the
 	logon sequence"""
 

--- a/lib/user.py
+++ b/lib/user.py
@@ -43,7 +43,8 @@ def clear_session():
 	"""Ends the logged in user's login session. The session remains but it 
 	is marked as being not logged in."""
 
-	app.logger.info('User "' + session['username'] + '" logged out from "' + request.remote_addr + '" using ' + request.user_agent.string)
+	if 'username' in session:
+		app.logger.info('User "' + session.get('username', 'unknown') + '" logged out from "' + request.remote_addr + '" using ' + request.user_agent.string)
 
 	# Remove the following items from the session
 	session.pop('logged_in', None)
@@ -53,11 +54,12 @@ def clear_session():
 
 ################################################################################
 
-def logon_ok(): 
+def logon_ok(username): 
 	"""This function is called post-logon or post TOTP logon to complete the
 	logon sequence"""
 
 	# Mark as logged on
+	session['username'] = username.lower()
 	session['logged_in'] = True
 
 	# Log a successful login

--- a/lib/user.py
+++ b/lib/user.py
@@ -3,7 +3,7 @@
 from cortex import app
 import cortex.lib.ldapc
 from flask import Flask, request, session, redirect, url_for, flash, g, abort, make_response, render_template, jsonify
-import os 
+import os
 import re
 import pwd
 import MySQLdb as mysql
@@ -64,10 +64,10 @@ def logon_ok(username):
 
 	# Log a successful login
 	app.logger.info('User "' + session['username'] + '" logged in from "' + request.remote_addr + '" using ' + request.user_agent.string)
-		
+
 	# Determine if "next" variable is set (the URL to be sent to)
 	next = request.form.get('next', default=None)
-	
+
 	if next == None:
 		return redirect(url_for('dashboard'))
 	else:
@@ -92,7 +92,7 @@ def get_users_groups(username, from_cache=True):
 	"""Returns a set (not a list) of groups that a user belongs to. The result is 
 	cached to improve performance and to lessen the impact on the LDAP server. The 
 	results are returned from the cache unless you set "from_cache" to be 
-	False. 
+	False.
 
 	This function will return None in all cases where the user was not found
 	or where the user has no groups. It is not expeceted that a user will ever
@@ -235,7 +235,7 @@ def does_user_have_permission(perm, user=None):
 	for p in perm:
 		if p in g.user_perms:
 			return True
-	
+
 	# We've not found the permission, return False to indicate that
 	app.logger.debug("User " + str(user) + " did not have permission(s) " + str(perm))
 	return False

--- a/views/user.py
+++ b/views/user.py
@@ -8,7 +8,7 @@ from cas_client import CASClient
 
 ################################################################################
 #CAS client init
-cas_client = CASClient(app.config['CAS_SERVER_URL'], app.config['CAS_SERVICE_URL'])
+cas_client = CASClient(app.config['CAS_SERVER_URL'], app.config['CAS_SERVICE_URL'], verify_certificates=True)
 
 ################################################################################
 
@@ -62,7 +62,6 @@ def login():
 		if ticket:
 			try:
 				cas_response = cas_client.perform_service_validate(ticket=ticket)
-				raise Exception()
 			except:
 				#CAS is not working falling back to LDAP
 				flash("CAS SSO is not working, falling back to LDAP authentication", 'alert-warning')

--- a/views/user.py
+++ b/views/user.py
@@ -26,7 +26,7 @@ def root():
 @app.route('/login', methods=['GET', 'POST'])
 def login():
 	"""Handles the login page, logging a user in on correct authentication."""
-		
+
 	# If the user is already logged in, just redirect them to their dashboard
 	if cortex.lib.user.is_logged_in():
 		return redirect(url_for('dashboard'))
@@ -55,7 +55,7 @@ def login():
 	# present LDAP auth
 	elif request.args.get('bypasscas', None) == '1':
 		return render_template('login.html')
-		
+
 	#otherwise perform cas auth
 	else:
 		ticket = request.args.get('ticket')

--- a/views/user.py
+++ b/views/user.py
@@ -7,31 +7,23 @@ import re
 from cas_client import CASClient
 
 ################################################################################
-#CAS client init
-cas_client = CASClient(app.config['CAS_SERVER_URL'], app.config['CAS_SERVICE_URL'], verify_certificates=True)
-
-################################################################################
 
 @app.route('/', methods=['GET', 'POST'])
 @app.disable_csrf_check
 def root():
-	if request.method == 'POST' and 'logoutRequest' in request.form:
-		cortex.lib.user.clear_session()
-		return ('', 200)
-	else:
-		return login()
-
-################################################################################
-
-@app.route('/login', methods=['GET', 'POST'])
-def login():
-	"""Handles the login page, logging a user in on correct authentication."""
-
 	# If the user is already logged in, just redirect them to their dashboard
 	if cortex.lib.user.is_logged_in():
 		return redirect(url_for('dashboard'))
+	else:
+		if app.config['USER_AUTH'] == 'cas':
+			return cas()
+		else:
+			return login()
 
-	# LDAP login
+###############################################################################
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
 	if request.method == 'POST':
 		if all(field in request.form for field in ['username', 'password']):
 			result = cortex.lib.user.authenticate(request.form['username'], request.form['password'])
@@ -51,29 +43,50 @@ def login():
 			# Logon is OK to proceed
 			return cortex.lib.user.logon_ok(request.form['username'])
 		abort(400)
+	return render_template('login.html')
 
-	# present LDAP auth
-	elif request.args.get('bypasscas', None) == '1':
-		return render_template('login.html')
+###############################################################################
 
-	#otherwise perform cas auth
-	else:
-		ticket = request.args.get('ticket')
-		if ticket:
+
+@app.route('/cas', methods=['GET', 'POST'])
+@app.disable_csrf_check
+def cas():
+	"""Handles the login page, logging a user in on correct authentication."""
+
+	#CAS client init
+	cas_client = CASClient(app.config['CAS_SERVER_URL'], app.config['CAS_SERVICE_URL'], verify_certificates=True)
+
+	#SLO
+	if request.method == 'POST' and session.get('cas_ticket') is not None and 'logoutRequest' in request.form:
+		#check the verify the ticket to prevent cross orign attacks
+		message = cas_client.parse_logout_request(request.form.get('logoutRequest'))
+		if message.get('session_index', None) == session.get('cas_ticket'):
+			cortex.lib.user.clear_session()
+			return ('', 200)
+		else:
+			abort(400)
+
+
+	# If the user is already logged in, just redirect them to their dashboard
+	if cortex.lib.user.is_logged_in():
+		return redirect(url_for('dashboard'))
+
+	ticket = request.args.get('ticket', None)
+	if ticket is not None:
+		try:
+			cas_response = cas_client.perform_service_validate(ticket=ticket)
+		except:
+			return root()
+		if cas_response and cas_response.success:
 			try:
-				cas_response = cas_client.perform_service_validate(ticket=ticket)
-			except:
-				#CAS is not working falling back to LDAP
-				flash("CAS SSO is not working, falling back to LDAP authentication", 'alert-warning')
-				return render_template('login.html')
-			if cas_response and cas_response.success:
-				try:
-					return cortex.lib.user.logon_ok(cas_response.attributes.get('uid'))
-				except KeyError:
-					#required user attributes not returned fallback to LDAP
-					alert("CAS SSO authentication successful but missing information, falling back to LDAP authentication", 'alert-warning')
-					return render_template('login.html')
-		return redirect(cas_client.get_login_url())
+				#keep the ticket for SLO
+				session['cas_ticket'] = ticket
+				return cortex.lib.user.logon_ok(cas_response.attributes.get('uid'))
+			except KeyError:
+				#required user attributes not returned
+				alert("CAS SSO authentication successful but missing required information consider using LDAP authentication", 'alert-warning')
+				return root()
+	return redirect(cas_client.get_login_url())
 
 ################################################################################
 
@@ -82,11 +95,18 @@ def login():
 def logout():
 	"""Logs a user out"""
 
+	#CAS client init
+	cas_client = CASClient(app.config['CAS_SERVER_URL'], app.config['CAS_SERVICE_URL'], verify_certificates=True)
+
+	cas_ticket = session.get('cas_ticket', None)
 	# destroy the session
 	cortex.lib.user.clear_session()
 
-	# Tell cas about the logout
-	return redirect(cas_client.get_logout_url())
+	if cas_ticket is not None:
+		# Tell cas about the logout
+		return redirect(cas_client.get_logout_url())
+	else:
+		return login()
 
 ################################################################################
 

--- a/views/user.py
+++ b/views/user.py
@@ -39,7 +39,7 @@ def login():
 			if not result:
 				flash('Incorrect username and/or password', 'alert-danger')
 				return render_template('login.html')
-			
+
 			# Permanent sessions
 			permanent = request.form.get('sec', default="")
 
@@ -84,7 +84,7 @@ def logout():
 
 	# destroy the session
 	cortex.lib.user.clear_session()
-	
+
 	# Tell cas about the logout
 	return redirect(cas_client.get_logout_url())
 


### PR DESCRIPTION
In reference to feature #114 support for CAS has been added.
This enables offloading of authentication and therefore asserting identity via multi factor or otherwise becomes the responsibility of the CAS server.
- cas_client has been used to implement this functionality
- The 'bypasscas' query string can be used to fallback to the existing LDAP login
- In the event that the CAS server cannot be contacted by Cortex for verification of the token. Authentication will fallback to LDAP
