### PR TITLE
Fail the cache VMware task when there are no vCenters.

### DIFF
--- a/neocortex/cache_vmware.py
+++ b/neocortex/cache_vmware.py
@@ -195,7 +195,7 @@ def run(helper, options):
 
 		# If no vCentres appear in the configuration.
 		else:
-			raise Exception("No vCentres found in configuration")
+			raise Exception("No vCenters found in configuration")
 
 		# Note: We delete the cache from the database after downloading all the data, so 
 		# as to not lock the table and have it empty whilst the job is running

--- a/neocortex/cache_vmware.py
+++ b/neocortex/cache_vmware.py
@@ -193,6 +193,10 @@ def run(helper, options):
 					clusters[key][moId]['total_ram_usage'] = total_ram_usage
 					clusters[key][moId]['host_count'] = len(cluster.host)
 
+		# If no vCentres appear in the configuration.
+		else:
+			raise Exception("No vCentres found in configuration")
+
 		# Note: We delete the cache from the database after downloading all the data, so 
 		# as to not lock the table and have it empty whilst the job is running
 


### PR DESCRIPTION
Added else to for loop, so if there are no vCenters to pull data from the task fails.