### PR TITLE
BUG FIX: PuppetDB class in SNPuppetConnector always returned the fact…

### DIFF
--- a/corpus/SNPuppetConnector.py
+++ b/corpus/SNPuppetConnector.py
@@ -312,7 +312,7 @@ class PuppetDB:
 		self.ssl_cert = ssl_cert
 		self.ssl_key = ssl_key
 		self.ssl_verify = ssl_verify
-		self.facts = None
+		self.facts = {}
 
 		# Connect
 		self.connect()
@@ -328,8 +328,8 @@ class PuppetDB:
 
 	def get_all_facts(self, node_object, cached=True):
 		"""Get facts about this node from puppet."""
-		if self.facts and cached:
-			return self.facts
+		if node_object.name in self.facts and cached:
+			return self.facts[node_object.name]
 		else:
 			facts = node_object.facts()
 			facts_dict = {}
@@ -337,7 +337,7 @@ class PuppetDB:
 				for fact in facts:
 					facts_dict[fact.name] = fact.value
 
-				self.facts = facts_dict
+				self.facts[node_object.name] = facts_dict
 
 			return facts_dict
 


### PR DESCRIPTION
…s about the same node from the cache after the first node was requested. As such the Puppet->ServiceNow sync task was writing the same information to every single host in ServiceNow. This commit changes the cache to be per-node so that it returns the data for the correct node, thus making it sync correctly