### PR TITLE
Added some error handling to allow the systems overview page.

### DIFF
--- a/templates/systems/overview.html
+++ b/templates/systems/overview.html
@@ -130,7 +130,7 @@ tr > td:first-child {
 			<div class="panel-heading">
 				<h3 class="panel-title">System Status</h3>
 			</div>
-			<div class="panel-body row">
+			<div id="systemStatusPanel" class="panel-body row">
 				{% if system.vmware_uuid %}
 				<div class="col-md-4">
 					<div style="text-align:center">
@@ -354,6 +354,13 @@ $('.power-ctl-form').submit(function(e) {
 });
 
 function update_data(data) {
+	// Added some error handling, to display an error message if one was present.
+	// This halts processing.
+	if ('error' in data) {
+		$('#systemStatusPanel').html('<p class="col-md-12"><span class="fa fa-info"></span> '+data['error']+'</p>');
+		return false;
+	}
+
 	$('.power_state').text(data.guest_state + ' (' + data.power_state + ')');
 	if (data.power_state === "poweredOn") {
 		$('#power-icon').attr("class", "fa fa-play fa-stack-1x icon-on");

--- a/views/systems.py
+++ b/views/systems.py
@@ -545,11 +545,6 @@ def system_status(id):
 	# Ensure that the system actually exists, and return a 404 if it doesn't
 	if system is None:
 		abort(404)
-	# get the VM
-	try:
-		vm = cortex.lib.systems.get_vm_by_system_id(id)
-	except ValueError as e:
-		abort(404)
 
 	data = {}
 	data['hostname'] = ''
@@ -557,6 +552,21 @@ def system_status(id):
 	data['search_domain'] = ''
 	routes = []
 	ipaddr = []
+
+	# get the VM
+	try:
+		vm = cortex.lib.systems.get_vm_by_system_id(id)
+	except ValueError as e:
+		abort(404)
+	except Exception as e:
+		# If we want to handle vCenter being unavailable gracefully.
+		if not app.config.get('HANDLE_UNAVAILABLE_VCENTER_GRACEFULLY', False):
+			raise e	
+		else:
+			vm = None
+			# Add an error field to the data we return, 
+			# so we can display a message on the template. 
+			data['error'] = 'Unable to retrieve system information, please check vCenter availability.'
 
 	if vm is not None and vm.guest is not None:
 		if vm.guest.ipStack is not None and len(vm.guest.ipStack) > 0:


### PR DESCRIPTION
This allow Cortex to handle a vCenter being unavailable gracefully. This is controlled by the config option HANDLE_UNAVAILABLE_VCENTER_GRACEFULLY, when set to True system_status will not raise an exception if it cannot connect to vCenter and instead adds an error message to the JSON returned. Closes #182.