### PR TITLE
Use group DN for primary key in LDAP group cache rather than CN, whic…

### DIFF
--- a/app.py
+++ b/app.py
@@ -509,10 +509,13 @@ Username:             %s
 		 PRIMARY KEY (`username`)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
 
+		cursor.execute("""DROP TABLE `ldap_group_cache`""")
+
 		cursor.execute("""CREATE TABLE IF NOT EXISTS `ldap_group_cache` (
 		 `username` varchar(64) NOT NULL,
+		 `group_dn` varchar(255) NOT NULL,
 		 `group` varchar(255) NOT NULL,
-		  PRIMARY KEY (`username`, `group`)
+		  PRIMARY KEY (`username`, `group_dn`)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
 
 		cursor.execute("""CREATE TABLE IF NOT EXISTS `ldap_group_cache_expire` (

--- a/lib/ldapc.py
+++ b/lib/ldapc.py
@@ -105,12 +105,12 @@ def get_users_groups_from_ldap(username):
 
 						matched = cn_regex.match(group)
 						if matched:
-							group = matched.group(2)
+							group_cn = matched.group(2)
 						else:
 							## didn't find the cn, so skip this 'group'
 							continue
 
-						curd.execute('INSERT INTO `ldap_group_cache` (`username`, `group`) VALUES (%s,%s)', (username,group.lower()))
+						curd.execute('INSERT INTO `ldap_group_cache` (`username`, `group_dn`, `group`) VALUES (%s, %s, %s)', (username, group.lower(), group_cn.lower()))
 						groups.append(group)
 
 					## Set the cache expiration


### PR DESCRIPTION
…h may not be unique. Drop LDAP cache each time Cortex restarts.