### PR TITLE
As an additional fix after the last LDAP fix, we need to truncate the…

### DIFF
--- a/app.py
+++ b/app.py
@@ -524,6 +524,8 @@ Username:             %s
 		  PRIMARY KEY (`username`)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
 
+		cursor.execute("""TRUNCATE `ldap_group_cache_expire`""")
+
 		cursor.execute("""CREATE TABLE IF NOT EXISTS `system_request` (
 		 `id` mediumint(11) NOT NULL AUTO_INCREMENT,
 		 `request_date` datetime NOT NULL,

--- a/lib/ldapc.py
+++ b/lib/ldapc.py
@@ -111,7 +111,7 @@ def get_users_groups_from_ldap(username):
 							continue
 
 						curd.execute('INSERT INTO `ldap_group_cache` (`username`, `group_dn`, `group`) VALUES (%s, %s, %s)', (username, group.lower(), group_cn.lower()))
-						groups.append(group)
+						groups.append(group_cn.lower())
 
 					## Set the cache expiration
 					curd.execute('REPLACE INTO `ldap_group_cache_expire` (`username`, `expiry_date`) VALUES (%s,NOW() + INTERVAL 15 MINUTE)', (username,))
@@ -119,7 +119,8 @@ def get_users_groups_from_ldap(username):
 					## Commit the transaction
 					g.db.commit()
 
-					return groups
+					# Return a sorted list so that it matches what we get from MySQL
+					return sorted(groups)
 				else:
 					return None
 			else:

--- a/lib/user.py
+++ b/lib/user.py
@@ -121,7 +121,7 @@ def get_users_groups(username, from_cache=True):
 		curd.execute('SELECT 1 FROM `ldap_group_cache_expire` WHERE `username` = %s AND `expiry_date` > CURDATE()', (username,))
 		if curd.fetchone() is not None:
 			## The cache has not expired, return the list
-			curd.execute('SELECT `group` FROM `ldap_group_cache` WHERE `username` = %s', (username,))
+			curd.execute('SELECT `group` FROM `ldap_group_cache` WHERE `username` = %s ORDER BY `group`', (username,))
 			groupdict = curd.fetchall()
 			groups = []
 			for group in groupdict:


### PR DESCRIPTION
… ldap_group_cache_expire table. Also made the non-cached version release the CNs rather than the DNs. As an additional fix, I've sorted both the cached and uncached lists so two subsequent runs from fresh produce identical results, which prior to all of this they didn't.