### PR TITLE
Implemented role based permissions for systems. 

### DIFF
--- a/app.py
+++ b/app.py
@@ -637,6 +637,65 @@ Username:             %s
 		  CONSTRAINT `system_perms_ibfk_1` FOREIGN KEY (`system_id`) REFERENCES `systems` (`id`) ON DELETE CASCADE
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
 
+		cursor.execute("""CREATE TABLE IF NOT EXISTS `system_roles` (
+		  `id` mediumint(11) NOT NULL AUTO_INCREMENT,
+		  `name` varchar(64) NOT NULL,
+		  `description` text NOT NULL,
+		  PRIMARY KEY (`id`),
+		  KEY (`name`)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
+
+		cursor.execute("""CREATE TABLE IF NOT EXISTS `system_role_perms` (
+		  `id` mediumint(11) NOT NULL AUTO_INCREMENT,
+		  `system_role_id` mediumint(11) NOT NULL,
+		  `perm` varchar(64) NOT NULL,
+		  PRIMARY KEY (`id`),
+		  UNIQUE (`system_role_id`, `perm`),
+		  CONSTRAINT `system_role_perms_ibfk_1` FOREIGN KEY (`system_role_id`) REFERENCES `system_roles` (`id`) ON DELETE CASCADE
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
+
+		cursor.execute("""CREATE TABLE IF NOT EXISTS `system_role_who` (
+		  `id` mediumint(11) NOT NULL AUTO_INCREMENT,
+		  `system_role_id` mediumint(11) NOT NULL,
+		  `who` varchar(128) NOT NULL,
+		  `type` tinyint(1) NOT NULL,
+		  PRIMARY KEY (`id`),
+		  UNIQUE (`system_role_id`, `who`, `type`),
+		  CONSTRAINT `system_role_who_ibfk_1` FOREIGN KEY (`system_role_id`) REFERENCES `system_roles` (`id`) ON DELETE CASCADE
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
+
+		cursor.execute("""CREATE TABLE IF NOT EXISTS `system_role_what` (
+		  `system_role_id` mediumint(11) NOT NULL,
+		  `system_id` mediumint(11) NOT NULL,
+		  PRIMARY KEY (`system_role_id`, `system_id`),
+		  CONSTRAINT `system_role_what_ibfk_1` FOREIGN KEY (`system_role_id`) REFERENCES `system_roles` (`id`) ON DELETE CASCADE,
+		  CONSTRAINT `system_role_what_ibfk_2` FOREIGN KEY (`system_id`) REFERENCES `systems` (`id`) ON DELETE CASCADE
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8""")
+
+		cursor.execute("""CREATE OR REPLACE VIEW `system_role_perms_view` AS
+		SELECT DISTINCT 
+		  `system_role_what`.`system_id`,
+		  `system_role_who`.`who`,
+		  `system_role_who`.`type`,
+		  `system_role_perms`.`perm`
+		FROM `system_roles`
+		LEFT JOIN `system_role_perms` ON `system_roles`.`id`=`system_role_perms`.`system_role_id`
+		LEFT JOIN `system_role_who` ON `system_roles`.`id`=`system_role_who`.`system_role_id`
+		LEFT JOIN `system_role_what` ON `system_roles`.`id`=`system_role_what`.`system_role_id`
+		WHERE 
+		  `system_role_what`.`system_id` IS NOT NULL AND
+		  `system_role_who`.`who` IS NOT NULL AND
+		  `system_role_who`.`type` IS NOT NULL AND
+		  `system_role_perms`.`perm` IS NOT NULL
+		UNION
+		SELECT DISTINCT
+		  `system_perms`.`system_id`,
+		  `system_perms`.`who`,
+		  `system_perms`.`type`,
+		  `system_perms`.`perm`
+		FROM `system_perms`;
+		""")
+
 		cursor.execute("""CREATE TABLE IF NOT EXISTS `system_user_favourites` (
 		  `username` varchar(255),
 		  `system_id` mediumint(11) NOT NULL,

--- a/lib/perms.py
+++ b/lib/perms.py
@@ -43,3 +43,55 @@ def get_role(id):
 		role['who'] = []
 
 	return role
+
+################################################################################
+
+def get_system_roles():
+	curd = g.db.cursor(mysql.cursors.DictCursor)
+	curd.execute("SELECT * FROM `system_roles` ORDER BY `name`")
+	return curd.fetchall()
+
+################################################################################
+
+def get_system_role(id):
+	curd = g.db.cursor(mysql.cursors.DictCursor)
+	curd.execute("SELECT * FROM `system_roles` WHERE `id` = %s", (id,))
+	role = curd.fetchone()
+	
+	## Return None if the role was not found
+	if role == None:
+		return None
+
+	# Add on the permissions assigned to the role
+	curd.execute("SELECT * FROM `system_role_perms` WHERE `system_role_id` = %s", (id,))
+	perms = curd.fetchall()
+
+	# Attach the perms to the 'role' dictionary
+	if perms != None:
+		role['perms'] = perms
+	else:
+		role['perms'] = []
+
+	# Add on the list of users assigned to the role
+	curd.execute("SELECT `system_role_who`.`id` AS `id`, `system_role_who`.`system_role_id` AS `system_role_id`, `system_role_who`.`who` AS `who`, `system_role_who`.`type` AS `type`, `realname_cache`.`realname` FROM `system_role_who` LEFT JOIN `realname_cache` ON `system_role_who`.`who` = `realname_cache`.`username` WHERE `system_role_id` = %s", (id,))
+	who = curd.fetchall()
+
+	# Attach the perms to the 'role' dictionary
+	if who != None:
+		role['who'] = who
+	else:
+		role['who'] = []
+
+	# Add on the list of systems assigned to the role.
+	curd.execute("SELECT `system_role_what`.`system_id`, `systems`.`name` FROM `system_role_what` LEFT JOIN `systems` ON `system_role_what`.`system_id`=`systems`.`id` WHERE `system_role_id`=%s", (id,))
+	what = curd.fetchall()
+
+	# Attach the systems to the role dictionary.
+	if what != None:
+		role['what'] = what
+	else:
+		role['what'] = []
+
+	return role
+
+

--- a/lib/systems.py
+++ b/lib/systems.py
@@ -203,7 +203,7 @@ def _build_systems_query(class_name = None, search = None, order = None, order_a
 			query = query + " AND "
 		else:
 			query = query + "WHERE "
-		query = query + ' `id` IN (SELECT DISTINCT `system_id` FROM `system_perms`)'
+		query = query + ' `id` IN (SELECT DISTINCT `system_id` FROM `system_role_perms_view`)'
 
 	if only_allocated_by:
 		if class_name is not None or search is not None or hide_inactive == True or only_other or show_expired or show_nocmdb or show_perms_only:

--- a/lib/user.py
+++ b/lib/user.py
@@ -291,10 +291,10 @@ def does_user_have_system_permission(system_id,sysperm,perm=None,user=None):
 
 	app.logger.debug("Checking system permissions for user " + str(user) + " on system " + str(system_id))
 
-	# Query the system_perms table to see if the user has the system
+	# Query the system_role_perms_view table to see if the user has the system
 	# explicitly given access to them
 	curd = g.db.cursor(mysql.cursors.DictCursor)
-	curd.execute('SELECT 1 FROM `system_perms` WHERE `system_id` = %s AND `who` = %s AND `type` = %s AND `perm` = %s', (system_id, user, ROLE_WHO_USER, sysperm))
+	curd.execute('SELECT 1 FROM `system_role_perms_view` WHERE `system_id` = %s AND `who` = %s AND `type` = %s AND `perm` = %s', (system_id, user, ROLE_WHO_USER, sysperm))
 
 	# If a row is returned then they have the permission
 	if len(curd.fetchall()) > 0:
@@ -305,17 +305,15 @@ def does_user_have_system_permission(system_id,sysperm,perm=None,user=None):
 
 	# Iterate over the groups, checking each group for the permission
 	for group in ldap_groups:
-		# Query the system_perms table to see if the permission is granted
+		# Query the system_role_perms_view table to see if the permission is granted
 		# to the group the user is in
-		curd.execute('SELECT 1 FROM `system_perms` WHERE `system_id` = %s AND `who` = %s AND `type` = %s AND `perm` = %s', (system_id, group.lower(), ROLE_WHO_LDAP_GROUP, sysperm))
+		curd.execute('SELECT 1 FROM `system_role_perms_view` WHERE `system_id` = %s AND `who` = %s AND `type` = %s AND `perm` = %s', (system_id, group.lower(), ROLE_WHO_LDAP_GROUP, sysperm))
 
 		# If a row is returned then they have access to the workflow
 		if len(curd.fetchall()) > 0:
 			return True
 
 	return False
-
-################################################################################
 
 #############################################################################
 
@@ -337,10 +335,10 @@ def does_user_have_any_system_permission(sysperm,user=None):
 
 	app.logger.debug("Checking to see if " + str(user) + " has system permission " + sysperm + " on any system")
 
-	# Query the system_perms table to see if the user has the system
+	# Query the system_role_perms_view table to see if the user has the system
 	# explicitly given access to them
 	curd = g.db.cursor(mysql.cursors.DictCursor)
-	curd.execute('SELECT 1 FROM `system_perms` WHERE `who` = %s AND `type` = %s AND `perm` = %s', (user, ROLE_WHO_USER, sysperm))
+	curd.execute('SELECT 1 FROM `system_role_perms_view` WHERE `who` = %s AND `type` = %s AND `perm` = %s', (user, ROLE_WHO_USER, sysperm))
 
 	# If a row is returned then they have the permission
 	if len(curd.fetchall()) > 0:
@@ -352,9 +350,9 @@ def does_user_have_any_system_permission(sysperm,user=None):
 
 	# Iterate over the groups, checking each group for the permission
 	for group in ldap_groups:
-		# Query the system_perms table to see if the permission is granted
+		# Query the system_role_perms_view table to see if the permission is granted
 		# to the group the user is in
-		curd.execute('SELECT 1 FROM `system_perms` WHERE `who` = %s AND `type` = %s AND `perm` = %s', (group.lower(), ROLE_WHO_LDAP_GROUP, sysperm))
+		curd.execute('SELECT 1 FROM `system_role_perms_view` WHERE `who` = %s AND `type` = %s AND `perm` = %s', (group.lower(), ROLE_WHO_LDAP_GROUP, sysperm))
 
 		# If a row is returned then they have access to the workflow
 		if len(curd.fetchall()) > 0:

--- a/request.py
+++ b/request.py
@@ -129,8 +129,8 @@ def context_processor():
 	perms = []
 	if does_user_have_permission("admin.permissions"):
 		perms.append({'link': url_for('perms_roles'), 'title': 'Permission Roles', 'icon': 'fa-user-secret'})
+		perms.append({'link': url_for('system_perms_roles'), 'title': 'System Permission Roles', 'icon': 'fa-user-secret'})
 		perms.append({'link': url_for('systems_withperms'), 'title': 'Systems with permissions', 'icon': 'fa-list'})
-		#perms.append({'link': url_for('perms_roles'), 'title': 'User lookup', 'icon': 'fa-users'})
 
 	injectdata['menu'] = { 'systems': systems, 'favourites': favourites, 'vmware': vmware, 'puppet': puppet, 'admin': admin, 'perms': perms }
 

--- a/templates/perms/role.html
+++ b/templates/perms/role.html
@@ -93,6 +93,34 @@
 	</div>
 </div>
 
+<div class="modal fade" id="addSystem" role="dialog">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<form role="form" method="POST" class="form-horizontal">
+				<input name="_csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+				<input name="action" type="hidden" value="add_system"/>
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+					<h4 class="modal-title">Add system</h4>
+				</div>
+				<div class="modal-body">
+					<div class="form-group">
+						<label class="col-sm-2 control-label">Name</label>
+						<div class="col-sm-10">
+							<input class="form-control" name="name" value="" placeholder="System name"/>
+						</div>
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+					<button type="submit" class="btn btn-primary">Add</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
+
+
 <div class="modal fade" id="remove" role="dialog">
 	<div class="modal-dialog">
 		<div class="modal-content">
@@ -115,6 +143,30 @@
 		</div>
 	</div>
 </div>
+
+<div class="modal fade" id="removeSystem" role="dialog">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<form role="form" method="POST" class="form-horizontal">
+				<input name="_csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+				<input name="action" type="hidden" value="remove_system"/>
+				<input id="remove-what-id" name="sid" type="hidden" value=""/>
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+					<h4 class="modal-title">Remove system</h4>
+				</div>
+				<div class="modal-body">
+					<p>Are you sure you want to remove '<span id="remove-what-text">unknown</span>' from this role?</p>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+					<button type="submit" class="btn btn-warning">Remove</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
+
 
 <div class="page-header">
 	<div class="pull-right">
@@ -141,6 +193,7 @@
 				<input name="action" type="hidden" value="update"/>
 
 				<fieldset>
+				{% if perms %}
 				<legend>Global permissions</legend>
 
 				{% for perm in perms %}
@@ -152,8 +205,11 @@
 				</div>
 				{% endfor %}
 				</fieldset>
+				{% endif %}
 
 				<fieldset>
+
+				{% if wfperms %}
 				<legend>Workflow permissions</legend>
 
 				{% for perm in wfperms %}
@@ -164,6 +220,20 @@
 					</label>
 				</div>
 				{% endfor %}
+				{% endif %}
+
+				{% if system_perms %}
+				<legend>System permissions</legend>
+
+				{% for perm in system_perms %}
+				<div class="checkbox">
+					<label>
+						<input type="checkbox" id="{{perm['name']}}" name="{{perm['name']}}" value="yes"{% if perm['name'] in rperms %} checked="checked"{%endif%}>
+						{{ perm['desc'] }}
+					</label>
+				</div>
+				{% endfor %}
+				{% endif %}
 				</fieldset>
 
 				<div class="text-center">
@@ -187,12 +257,28 @@
 				{% endfor %}
 			</table>
 		</div>
+		{% if 'what' in role %}
+		<div class="panel panel-default">
+			<div class="panel-heading"><strong>Systems</strong><div class="pull-right"><a data-toggle="modal" data-target="#addSystem" class="btn btn-xs btn-success"><i class="fa fa-fw fa-plus"></i></a></a></div></div>
+			<table class="table table-striped table-hover">
+				{% for what in role['what'] %}
+				<tr>
+					<td><span class="text-muted"><i class="fa fa-server"> </i> System</span> {{what['name']}}</td>
+					<td class="text-right"><a data-toggle="modal" data-target="#removeSystem" data-name="{{what['name']}}" data-sid="{{what['system_id']}}" class="btn btn-xs btn-danger">Remove</a></td>
+				</tr>
+				{%else%}
+				<tr><td colspan="2"><span class="text-muted">No systems have been assigned to this role</span></td></tr>
+				{% endfor %}
+			</table>
+		</div>
+		{% endif %}
 	</div>
 </div>
 
 <script type="text/javascript">
 $( document ).ready(function() 
 {
+	/* What is this doing?? */
 	$('#revoke').on('show.bs.modal', function (event)
 	{
 		var link = $(event.relatedTarget)
@@ -208,6 +294,15 @@ $( document ).ready(function()
 		$('#remove-who-text').text(link.data('name'));
 		$('#remove-who-id').val(link.data('wid'));
 	})
+	
+	$('#removeSystem').on('show.bs.modal', function (event)
+	{
+		var link = $(event.relatedTarget)
+
+		$('#remove-what-text').text(link.data('name'));
+		$('#remove-what-id').val(link.data('sid'));
+	})
+
 
 });
 </script>

--- a/templates/perms/roles.html
+++ b/templates/perms/roles.html
@@ -1,6 +1,5 @@
 {% extends "layout.html" %}
 {% block body %}
-
 <div class="modal fade" id="create" role="dialog">
 	<div class="modal-dialog">
 		<div class="modal-content">
@@ -38,7 +37,7 @@
 	<div class="pull-right">
 		<a data-toggle="modal" data-target="#create" class="btn btn-primary btn-sm"><i class="fa fa-fw fa-plus"></i> <span class="hidden-sm hidden-xs">Create role</span></a>
 	</div>
-	<h3><i class="fa fa-fw fa-user-secret"></i> Roles</h3>
+	<h3><i class="fa fa-fw fa-user-secret"></i> {{ title }}</h3>
 	<p class="text-muted">A role is a group of permissions. Users are given one or more roles which grant them the permissions assigned to those roles</p>
 </div>
 
@@ -55,7 +54,7 @@
 		<tr>
 			<td>{{ role.name }}</td>
 			<td>{{ role.description }}</td>
-			<td><a href="{{ url_for('perms_role',id=role.id) }}" class="btn btn-xs btn-default"><i class="fa fa-fw fa-edit"></i>Manage</a></td>
+			<td><a href="{{ url_for(manage_role_route,id=role.id) }}" class="btn btn-xs btn-default"><i class="fa fa-fw fa-edit"></i>Manage</a></td>
 		</tr>
 {%- endfor %}
 	</tbody>

--- a/views/perms.py
+++ b/views/perms.py
@@ -3,6 +3,7 @@
 from cortex import app
 import cortex.lib.perms
 import cortex.lib.user
+import cortex.lib.systems
 import cortex.lib.core
 from cortex.lib.user import does_user_have_permission
 from flask import request, session, redirect, url_for, flash, g, abort, render_template
@@ -29,7 +30,7 @@ def perms_roles():
 		roles = cortex.lib.perms.get_roles()
 
 		# Render the page
-		return render_template('perms/roles.html', active='perms', title="Roles", roles=roles)
+		return render_template('perms/roles.html', active='perms', title="Roles", roles=roles, manage_role_route='perms_role')
 
 	## Create new role
 	elif request.method == 'POST':
@@ -59,6 +60,57 @@ def perms_roles():
 
 		flash("Role created", "alert-success")
 		return redirect(url_for('perms_roles'))
+
+
+################################################################################
+
+@app.route('/permissions/system/roles',methods=['GET','POST'])
+@cortex.lib.user.login_required
+def system_perms_roles():
+
+	# Check user permissions
+	if not does_user_have_permission("admin.permissions"):
+		abort(403)
+
+	# Cursor for the DB
+	curd = g.db.cursor(mysql.cursors.DictCursor)
+
+	## View list
+	if request.method == 'GET':
+		# Get the list of roles from the database
+		roles = cortex.lib.perms.get_system_roles()
+
+		# Render the page
+		return render_template('perms/roles.html', active='perms', title="System Roles", roles=roles, manage_role_route='system_perms_role')
+	
+	## Create new role
+	elif request.method == 'POST':
+
+		# Validate role name/prefix
+		name = request.form['name']
+		if not re.match(r'^[a-zA-Z0-9\s\-\_\'\"\&\@\,\:]{3,64}$', name):
+			flash("The name you chose is invalid. It can only contain lowercase letters and be at least 3 characters long and at most 64", "alert-danger")
+			return redirect(url_for('system_perms_roles'))
+
+		# Validate the description
+		desc = request.form['description']
+		if not re.match(r'^.{3,512}$', desc):
+			flash("The description you sent was invalid. It must be between 3 and 512 characters long.", "alert-danger")
+			return redirect(url_for('system_perms_roles'))
+
+		# Check if the class already exists
+		curd.execute('SELECT 1 FROM `system_roles` WHERE `name` = %s;', (name,))
+		if curd.fetchone() is not None:
+			flash('A role already exists with that name', 'alert-danger')
+			return redirect(url_for('system_perms_roles'))
+
+		# SQL insert
+		curd.execute("INSERT INTO `system_roles` (`name`, `description`) VALUES (%s, %s)", (name, desc))
+		g.db.commit()
+		cortex.lib.core.log(__name__, "permissions.system.role.create", "Permission system role '" + name + "' created")
+
+		flash("System Role created", "alert-success")
+		return redirect(url_for('system_perms_roles'))
 
 
 ################################################################################
@@ -238,6 +290,237 @@ def perms_role(id):
 			return redirect(url_for('perms_role',id=id))
 		else:
 			abort(400)
+
+
+################################################################################
+
+@app.route('/permissions/system/role/<int:id>',methods=['GET','POST'])
+@cortex.lib.user.login_required
+def system_perms_role(id):
+	"""View function to let administrators view and manage a role"""
+	
+	# Check user permissions
+	if not does_user_have_permission("admin.permissions"):
+		abort(403)
+
+	# Cursor for the DB
+	curd = g.db.cursor(mysql.cursors.DictCursor)
+
+	# Get the system role from the database
+	role = cortex.lib.perms.get_system_role(id)
+
+	# Catch when no role exists
+	if role == None:
+		abort(404)
+
+	# Build a simple list of all the permissions the role has, for calculating
+	# permissions during the view/GET or during updating in a POST
+	plist = []
+	for perm in role['perms']:
+		plist.append(perm['perm'])
+
+	## View list
+	if request.method == 'GET':
+		# Render the page
+		return render_template('perms/role.html', active='perms', title="System Role", role=role, system_perms=app.system_permissions, rperms=plist)
+
+	## Edit role, delete role
+	elif request.method == 'POST':
+		action = request.form['action']
+
+		# delete        - delete the role
+		# edit          - change name/desc of the role
+		# update        - Update the list of permissions 
+		# add           - Give a user this role
+		# remove        - Revoke from a user this role
+		# add_system    - Add a system to this role.
+		# remove_system - Remove a system from this role.
+
+		# Delete the role
+		if action == 'delete':
+			curd.execute('''DELETE FROM `system_roles` WHERE `id` = %s''', (id,))
+			g.db.commit()
+
+			cortex.lib.core.log(__name__, "permissions.system.role.delete", "Role '" + role['name'] + "' (" + str(id) + ")" + " deleted")
+			flash("The system role `" + role['name'] + "` has been deleted", "alert-success")
+			return redirect(url_for('system_perms_roles'))
+
+		# Change the name and/or description of the role
+		elif action == 'edit':
+			# Validate class name/prefix
+			name = request.form['name']
+			if not re.match(r'^[a-zA-Z0-9\s\-\_\'\"\&\@\,\:]{3,64}$', name):
+				flash("The name you sent was invalid", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+
+			# Validate the description
+			desc = request.form['description']
+			if not re.match(r'^.{3,512}$', desc):
+				flash("The description you sent was invalid. It must be between 3 and 512 characters long.", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+
+			curd.execute('''UPDATE `system_roles` SET `name` = %s, `description` = %s WHERE `id` = %s''', (name, desc, id))
+			g.db.commit()
+			cortex.lib.core.log(__name__, "permissions.system.role.edit", "Role '" + role['name'] + "' (" + str(id) + ")" + " name/description edited")
+
+			flash("System Role updated", "alert-success")
+			return redirect(url_for('system_perms_role',id=id))
+
+		elif action == 'update':
+			# Loop over all the permissions available, check if it is in the form
+			# if it isn't, make sure to delete from the table
+			# if it is, make sure it is in the table
+			perms = app.system_permissions
+			changes = 0
+
+			for perm in perms:
+				## Check if the role already has this permission or not
+				curd.execute('SELECT 1 FROM `system_role_perms` WHERE `system_role_id` = %s AND `perm` = %s', (id,perm['name']))
+				if curd.fetchone() is None:
+					exists = False
+				else:
+					exists = True
+
+				should_exist = False
+				if perm['name'] in request.form:
+					if request.form[perm['name']] == 'yes':
+						should_exist = True
+
+				if not should_exist and exists:
+					curd.execute('''DELETE FROM `system_role_perms` WHERE `system_role_id` = %s AND `perm` = %s''', (id, perm['name']))
+					g.db.commit()
+					cortex.lib.core.log(__name__, "permissions.system.role.revoke", "Permission '" + perm['name'] + "' removed from system role '" + role['name'] + "' (" + str(id) + ")")
+					changes += 1
+
+				elif should_exist and not exists:
+					curd.execute('''INSERT INTO `system_role_perms` (`system_role_id`, `perm`) VALUES (%s, %s)''', (id, perm['name']))
+					g.db.commit()
+					cortex.lib.core.log(__name__, "permissions.system.role.grant", "Permission '" + perm['name'] + "' added to system role '" + role['name'] + "' (" + str(id) + ")")
+					changes += 1
+
+			if changes == 0:
+				flash("Permissions were not updated - no changes requested", "alert-warning")
+			else:
+				flash("Permissions for the system role were successfully updated", "alert-success")
+			return redirect(url_for('system_perms_role',id=id))
+
+		## Add a user or group to the role
+		elif action == 'add':
+			name = request.form['name']
+			if not re.match(r'^[a-zA-Z0-9\-\_]{3,255}$', name):
+				flash("The user or group name you sent was invalid", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+
+			ptype = request.form['type']
+			if not re.match(r'^[0-9]+$',ptype):
+				flash("The type you sent was invalid", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+			else:
+				ptype = int(ptype)
+
+			if ptype not in [0, 1]:
+				flash("The type you sent was invalid", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+
+			if ptype == 0:
+				hstr = "user"
+
+				if not cortex.lib.user.does_user_exist(name):
+					flash("The username you sent does not exist", "alert-danger")
+					return redirect(url_for('system_perms_role',id=id))
+
+			elif ptype == 1:
+				hstr = "group"
+
+				if not cortex.lib.ldapc.does_group_exist(name):
+					flash("The Active Directory group you specified does not exist", "alert-danger")
+					return redirect(url_for('system_perms_role',id=id))
+
+			# Ensure the user/group combo was not already added
+			curd.execute('SELECT 1 FROM `system_role_who` WHERE `system_role_id` = %s AND `who` = %s AND `type` = %s', (id,name,ptype))
+			if curd.fetchone() is not None:
+				flash('That user/group is already added to the system role', 'alert-warning')
+				return redirect(url_for('system_perms_role',id=id))
+
+			curd.execute('''INSERT INTO `system_role_who` (`system_role_id`, `who`, `type`) VALUES (%s, %s, %s)''', (id, name, ptype))
+			g.db.commit()
+			cortex.lib.core.log(__name__, "permissions.system.role.member.add", hstr + " '" + name + "' added to system role '" + role['name'] + "' (" + str(id) + ")")
+
+			flash("The " + hstr + " " + name + " was added to the system role", "alert-success")
+			return redirect(url_for('system_perms_role',id=id))
+
+		## Remove a user or group from the role
+		elif action == 'remove':
+			wid = request.form['wid']
+			if not re.match(r'^[0-9]+$',wid):
+				flash("The user/group ID you sent was invalid", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+
+			# Ensure the permission was not already granted
+			curd.execute('SELECT `who` FROM `system_role_who` WHERE `id` = %s', (wid,))
+			who_row = curd.fetchone()
+			if who_row is None:
+				flash('That user/group is not added to the system role', 'alert-warning')
+				return redirect(url_for('system_perms_role',id=id))
+
+			curd.execute('''DELETE FROM `system_role_who` WHERE `id` = %s''', (wid,))
+			g.db.commit()
+			cortex.lib.core.log(__name__, "permissions.system.role.member.remove", "The user/group '" + who_row['who'] + "' was removed from system role '" + role['name'] + "' (" + str(id) + ")")
+
+			flash("The user or group was revoked from the system role", "alert-success")
+			return redirect(url_for('system_perms_role',id=id))
+
+		## Add a system to the role.
+		elif action == 'add_system':
+			name = request.form['name']
+			if not re.match(r'^[a-zA-Z0-9\-\_]{3,255}$', name):
+				flash("The system name you sent was invalid", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+
+			# Get the system.
+			system = cortex.lib.systems.get_system_by_name(name)
+			if system is None:
+				flash('The system you sent does not exist.', 'alert-danger')
+				return redirect(url_for('system_perms_role',id=id))
+
+			# Ensure the system isn't already added.
+			curd.execute("SELECT 1 FROM `system_role_what` WHERE `system_role_id`=%s and `system_id`=%s", (id, system['id']))
+			if curd.fetchone() is not None:
+				flash('That system has already been added to the system role.')
+				return redirect(url_for('system_perms_role',id=id))
+
+			# Add the system.
+			curd.execute("INSERT INTO `system_role_what` (`system_role_id`, `system_id`) VALUES (%s, %s);", (id, system['id']))
+			g.db.commit()
+			cortex.lib.core.log(__name__, "permissions.system.role.system.add", "The system '" + system['name'] + "' (" + str(system['id']) + ") was added to the system role '" + role['name'] + "' (" + str(id) + ")")
+
+			flash("The system was added from the system role", "alert-success")
+			return redirect(url_for('system_perms_role',id=id))
+
+		## Remove a system from this role.
+		elif action == 'remove_system':
+			sid = request.form['sid']
+			if not re.match(r'^[0-9]+$',sid):
+				flash("The system ID you sent was invalid", "alert-danger")
+				return redirect(url_for('system_perms_role',id=id))
+
+			# Ensure this system is attached to this role.
+			curd.execute("SELECT 1 FROM `system_role_what` WHERE `system_role_id`=%s AND `system_id`=%s", (id, sid))
+			what_row = curd.fetchone()
+			if what_row is None:
+				flash('That system is not added to the system role', 'alert-warning')
+				return redirect(url_for('system_perms_role',id=id))
+				
+			curd.execute("DELETE FROM `system_role_what` WHERE `system_role_id`=%s AND `system_id`=%s", (id, sid))
+			g.db.commit()
+			cortex.lib.core.log(__name__, "permissions.system.role.system.remove", "System ID '" + str(sid) + "'was removed from the system role '" + role['name'] + "' (" + str(id) + ")")
+
+			flash("The system was removed from the system role", "alert-success")
+			return redirect(url_for('system_perms_role',id=id))
+
+		else:
+			abort(400)
+
 
 ################################################################################
 

--- a/views/views.py
+++ b/views/views.py
@@ -60,7 +60,7 @@ def dashboard():
 	tasks = curd.fetchall()
 
 	# Get the list of systems the user is specifically allowed to view
-	curd.execute("SELECT * FROM `systems_info_view` WHERE `id` IN (SELECT `system_id` FROM `system_perms` WHERE (`type` = '0' AND `who` = %s AND (`perm` = 'view' OR `perm` = 'view.overview' OR `perm` = 'view.detail')) OR (`type` = '1' AND (`perm` = 'view' OR `perm` = 'view.overview' OR `perm` = 'view.detail') AND `who` IN (SELECT `group` FROM `ldap_group_cache` WHERE `username` = %s)))",(session['username'],session['username']))
+	curd.execute("SELECT * FROM `systems_info_view` WHERE `id` IN (SELECT `system_id` FROM `system_role_perms_view` WHERE (`type` = '0' AND `who` = %s AND (`perm` = 'view' OR `perm` = 'view.overview' OR `perm` = 'view.detail')) OR (`type` = '1' AND (`perm` = 'view' OR `perm` = 'view.overview' OR `perm` = 'view.detail') AND `who` IN (SELECT `group` FROM `ldap_group_cache` WHERE `username` = %s)))",(session['username'],session['username']))
 	systems = curd.fetchall()
 
 	# Recent systems


### PR DESCRIPTION
Created extra tables to facilitate role based permissions for systems, along with a view 'system_role_perms_view' which should be a drop in replacement for 'system_perms'.

Admins can manage system role permissions using the same interface as managing roles, with the additional panel for systems the role is affecting.

Closes #155 