### PR TITLE
Enc wrapper noop

### DIFF
--- a/bin/cortex-enc-wrapper
+++ b/bin/cortex-enc-wrapper
@@ -53,6 +53,10 @@ try:
 		ssl_verify = config.getboolean('enc', 'ssl_verify')
 	else:
 		ssl_verify = True
+	if config.has_option('enc', 'limit_to_nodes'):
+		limit_to_nodes = [entry.strip().lower() for entry in config.get('enc', 'limit_to_nodes').split(',')]
+	else:
+		limit_to_nodes = None
 except Exception as e:
 	print >> sys.stderr, 'Failed to get configuration option: ' + str(e)
 	syslog.syslog(syslog.LOG_ERR, "Failed to get configuration option: " + str(e))
@@ -61,36 +65,45 @@ except Exception as e:
 # Get the certname of the node to find
 certname = sys.argv[1]
 
-# Request the page, and don't print out the InsecureRequestWarning
-try:
-	with warnings.catch_warnings():
-		if not ssl_verify:
-			warnings.simplefilter("ignore", requests.packages.urllib3.exceptions.InsecureRequestWarning)
-		r = requests.get(cortex_url + '/' + certname, headers={'Accept': 'application/yml', 'X-Auth-Token': auth_token}, verify=ssl_verify)
-except Exception as e:
-	# On exception, attempt to print cache
-	sys.exit(print_catalog(certname, cache_dir))
+# If we're not restricted to a node set, or we are but the requested node is in the set:
+if limit_to_nodes is None or certname.lower() in limit_to_nodes:
+	# Request the page, and don't print out the InsecureRequestWarning
+	try:
+		with warnings.catch_warnings():
+			if not ssl_verify:
+				warnings.simplefilter("ignore", requests.packages.urllib3.exceptions.InsecureRequestWarning)
+			r = requests.get(cortex_url + '/' + certname, headers={'Accept': 'application/yml', 'X-Auth-Token': auth_token}, verify=ssl_verify)
+	except Exception as e:
+		# On exception, attempt to print cache
+		sys.exit(print_catalog(certname, cache_dir))
 
-# On a 200 OK response, we should cache the catalog and print it out for the ENC
-if r.status_code == 200:
-	# Cache the catalog to the file system
-	cache_catalog(certname, r.text, cache_dir)
+	# On a 200 OK response, we should cache the catalog and print it out for the ENC
+	if r.status_code == 200:
+		# Cache the catalog to the file system
+		cache_catalog(certname, r.text, cache_dir)
 
-	# Return the catalog to Puppet
-	print r.text
-	sys.exit(0)
+		# Return the catalog to Puppet
+		print r.text
+		sys.exit(0)
 
-# On a 404 Not Found response, print out an empty catalog
-elif r.status_code == 404:
-	# Return blank catalog to Pupper
-	print "classes:"
-	syslog.syslog(syslog.LOG_WARNING, "Returning blank catalog - cortex returned 404 for node " + certname)
-	sys.exit(0)
+	# On a 404 Not Found response, print out an empty catalog
+	elif r.status_code == 404:
+		# Return blank catalog to Puppet
+		print "classes:"
+		syslog.syslog(syslog.LOG_WARNING, "Returning blank catalog - cortex returned 404 for node " + certname)
+		sys.exit(0)
 
-# On any other response, attempt to return the cache
+	# On any other response, attempt to return the cache
+	else:
+		syslog.syslog(syslog.LOG_WARNING, "Returning cached catalog - cortex returned " + str(r.status_code) + " for node " + certname)
+		sys.exit(print_catalog(certname, cache_dir))
+
+# We're restricted to a node set, and the node is missing
 else:
-	syslog.syslog(syslog.LOG_WARNING, "Returning cached catalog - cortex returned " + str(r.status_code) + " for node " + certname)
-	sys.exit(print_catalog(certname, cache_dir))
+	# Return blank catalog to Puppet
+	print "classes:"
+	syslog.syslog(syslog.LOG_WARNING, "Returning blank catalog - requested node " + certname + " is not in limit_to_nodes list")
+	sys.exit(0)
 
 # Shouldn't get here
 sys.exit(1)


### PR DESCRIPTION
Added limit_to_nodes option to cortex-enc-wrapper to allow for a sort of server-side no-op, which can be useful for Puppet upgrades