### PR TITLE
Removed the duplication of code of rubrik.py being in both corpus/ an…

### DIFF
--- a/app.py
+++ b/app.py
@@ -643,6 +643,7 @@ Username:             %s
 		  `sncache_cmdb_ci`.`os` AS `cmdb_os`,
 		  `sncache_cmdb_ci`.`short_description` AS `cmdb_short_description`,
 		  `sncache_cmdb_ci`.`virtual` AS `cmdb_is_virtual`,
+		  `vmware_cache_vm`.`id` AS `vmware_moid`,
 		  `vmware_cache_vm`.`name` AS `vmware_name`,
 		  `vmware_cache_vm`.`vcenter` AS `vmware_vcenter`,
 		  `vmware_cache_vm`.`uuid` AS `vmware_uuid`,
@@ -664,9 +665,9 @@ Username:             %s
 		LEFT JOIN `sncache_cmdb_ci` ON `systems`.`cmdb_id` = `sncache_cmdb_ci`.`sys_id`
 		LEFT JOIN `vmware_cache_vm` ON `systems`.`vmware_uuid` = `vmware_cache_vm`.`uuid`
 		LEFT JOIN `puppet_nodes` ON `systems`.`id` = `puppet_nodes`.`id` 
-		LEFT JOIN `realname_cache` AS  `allocation_who_realname_cache` ON `systems`.`allocation_who` = `allocation_who_realname_cache`.`username`
-		LEFT JOIN `realname_cache` AS  `primary_owner_who_realname_cache` ON `systems`.`primary_owner_who` = `primary_owner_who_realname_cache`.`username`
-		LEFT JOIN `realname_cache` AS  `secondary_owner_who_realname_cache` ON `systems`.`secondary_owner_who` = `secondary_owner_who_realname_cache`.`username`""")
+		LEFT JOIN `realname_cache` AS `allocation_who_realname_cache` ON `systems`.`allocation_who` = `allocation_who_realname_cache`.`username`
+		LEFT JOIN `realname_cache` AS `primary_owner_who_realname_cache` ON `systems`.`primary_owner_who` = `primary_owner_who_realname_cache`.`username`
+		LEFT JOIN `realname_cache` AS `secondary_owner_who_realname_cache` ON `systems`.`secondary_owner_who` = `secondary_owner_who_realname_cache`.`username`""")
        	
 		cursor.execute("""CREATE TABLE IF NOT EXISTS `roles` (
 		  `id` mediumint(11) NOT NULL AUTO_INCREMENT,

--- a/lib/rubrik.py
+++ b/lib/rubrik.py
@@ -1,82 +1,8 @@
 from cortex import app
-from flask import g
+import cortex.corpus.rubrik 
 
-import requests
-
-from urllib.parse import urljoin
-from urllib.parse import quote
-
-class Rubrik(object):
-	"""A restful client for Rubrik"""
-
-	def __init__(self):
-		self.api_url_base = app.config['RUBRIK_API_URL_BASE']
-		self.headers = {'Accept': 'application/json'}
-		self.rubrik_api_user = app.config['RUBRIK_API_USER']
-		self.rubrik_api_pass = app.config['RUBRIK_API_PASS']
-		self.get_api_token()
-
-	def get_api_token(self):
-		url = urljoin(self.api_url_base, 'session')
-		try:
-			r = requests.post(url, headers={'Accept': 'application/json'},
-								auth=(self.rubrik_api_user, self.rubrik_api_pass),
-								verify=False)
-			r.raise_for_status()
-			self.headers['Authorization'] = 'Bearer ' + r.json().get('token')
-		except requests.exceptions.HTTPError as e:
-			raise
-
-
-	def get_request(self, api_call, payload=None):
-		url = urljoin(self.api_url_base, api_call)
-		try:
-			r = requests.get(url, headers=self.headers,
-					params=payload, verify=False)
-			r.raise_for_status()
-			return r.json()
-		except requests.exceptions.HTTPError as e:
-			raise
-		except ValueError as e:
-			#json decode fail
-			raise
-
-	def patch_request(self, api_call, payload={}):
-		url = urljoin(self.api_url_base, api_call)
-		try:
-			r = requests.patch(url, headers=self.headers,
-								json=payload, verify=False)
-			r.raise_for_status()
-			return r.json()
-		except requests.exceptions.HTTPError as e:
-			raise
-		except ValueError as e:
-			#json decode fail
-			raise
-
-	def get_sla_domains(self):
-		"""Gets the backup SLA categories from Rubrik"""
-		return self.get_request('sla_domain')
-
-	def get_vm(self, name):
-		"""Detailed view of a VM
-		param id ID of the virtual machine
-		"""
-		try:
-			#try to get the only vm in the response
-			try:
-				return self.get_request('vmware/vm', {'name': quote(name), 'limit':
-			1})['data'][0]
-			except IndexError:
-				# In the event the system is not found
-				return None
-		except KeyError:
-			raise Exception('VM not found')
-
-	def get_vm_snapshots(self, id):
-		"""Get a list of snapshots for the vm"""
-		return self.get_request('vmware/vm/' + quote(id) + '/snapshot')
-
-	def update_vm(self, id, data):
-		"""update a vm with a new set of properties"""
-		return self.patch_request('vmware/vm/' + quote(id), data)
+# This class is just a thin wrapper around the corpus Rubrik object, that pulls 
+# config from our global app object rather than needing a TaskHelper object
+class Rubrik(cortex.corpus.rubrik.Rubrik):
+	def __init__(self, helper=None):
+		super().__init__(app)

--- a/neocortex/TaskHelper.py
+++ b/neocortex/TaskHelper.py
@@ -95,6 +95,9 @@ class TaskHelper(object):
 			('neocortex.task',self.task_id, self.workflow_name + "." + 'exception', self.username, "The task failed because an exception was raised: " + exception_type + " - " + exception_message, self.STATUS_FAILED))
 		self.db.commit()
 
+		import traceback
+		syslog.syslog('Unhandled exception caused task to end:\n' + traceback.format_exc())
+
 	def _log_fatal_error(self, message):
 		"""Logs a fatal error into the events for this task"""
 

--- a/neocortex/rubrik_crcheck.py
+++ b/neocortex/rubrik_crcheck.py
@@ -6,7 +6,7 @@ def run(helper, options):
 
 	helper.event('get_current_status', 'Getting the current Cortex-defined backup status of systems')
 	curd = helper.db.cursor(mysql.cursors.DictCursor)
-	curd.execute("SELECT `id`, `name`, `cmdb_environment`, `enable_backup` FROM `systems_info_view` WHERE `decom_date` IS NULL AND `enable_backup` != 2")
+	curd.execute("SELECT * FROM `systems_info_view` WHERE `decom_date` IS NULL AND `enable_backup` != 2")
 	vms_in_server = curd.fetchall()
 	helper.end_event(description='Retrieved all the systems')
 
@@ -37,7 +37,7 @@ def run(helper, options):
 	changes = 0
 	for cortex_vm_data in vms_in_server:
 		# retrieving the info that Rubrik has on the device
-		rubrik_vm_data = rubrik_connection.get_vm(cortex_vm_data['name'])
+		rubrik_vm_data = rubrik_connection.get_vm(cortex_vm_data)
 		
 		# If Rubrik doesn't have any data on it, there's nothing we can do. This should NOT happen though - it's possibly pointing to user error
 		if rubrik_vm_data == None:

--- a/views/systems.py
+++ b/views/systems.py
@@ -386,7 +386,7 @@ def system_backup(id):
 			abort(404)
 
 		try:
-			vm = rubrik.get_vm(system['name'])
+			vm = rubrik.get_vm(system)
 		except:
 			abort(500)
 
@@ -410,7 +410,7 @@ def system_backup(id):
 		abort(404)
 
 	try:
-		vm = rubrik.get_vm(system['name'])
+		vm = rubrik.get_vm(system)
 	except:
 		abort(500)
 
@@ -783,14 +783,15 @@ def system_edit(id):
 				review_status = system['review_status']
 				review_task = system['review_task']
 
-			if system['enable_backup'] in [1, 2] and enable_backup == 0:
+			if int(system['enable_backup']) in [1, 2] and int(enable_backup) == 0:
 				rubrik = cortex.lib.rubrik.Rubrik()
 				try:
-					vm = rubrik.get_vm(system['name'])
+					vm = rubrik.get_vm(system)
 				except Exception as e:
 					flash("Failed to get VM from Rubrik", "alert-danger")
 				else:
 					rubrik.update_vm(vm['id'], {'configuredSlaDomainId': 'UNPROTECTED'})
+					flash("Re-configured system to NOT backup in Rubrik!", "alert-warning")
 
 			# Update the system
 			curd.execute('UPDATE `systems` SET `allocation_comment` = %s, `cmdb_id` = %s, `vmware_uuid` = %s, `enable_backup` = %s, `review_status` = %s, `review_task` = %s, `expiry_date` = %s, `primary_owner_who`=%s, `primary_owner_role`=%s, `secondary_owner_who`=%s, `secondary_owner_role`=%s WHERE `id` = %s', (request.form['allocation_comment'].strip(), cmdb_id, vmware_uuid, enable_backup, review_status, review_task, expiry_date, primary_owner_who, primary_owner_role, secondary_owner_who, secondary_owner_role, id))


### PR DESCRIPTION
…d lib/. Modified get_vm to take a systems_info_view row so we can uniquely identify VMs. Resolves #307 - Rubrik tab now shows the correct VM even when there are two VMs with identical names. Fixed another issue whereby changing the backup status to 'Do NOT backup' on a system page didn't actually change it in Rubrik.

Also made neocortex log exceptions and tracebacks to syslog when an exception occurs during a workflow that causes it to terminate.