### PR TITLE
Rubrik policy check and logging fixes

### DIFF
--- a/corpus/rubrik.py
+++ b/corpus/rubrik.py
@@ -1,19 +1,17 @@
-from flask import g
-
 import requests
 
 from urllib.parse import urljoin
 from urllib.parse import quote
 
 class Rubrik(object):
-	"""A restful client for Rubrik"""
+	"""A RESTful client for Rubrik"""
 
 	def __init__(self, helper):
-		app = helper
-		self.api_url_base = app.config['RUBRIK_API_URL_BASE']
+		self.helper = helper
+		self.api_url_base = helper.config['RUBRIK_API_URL_BASE']
 		self.headers = {'Accept': 'application/json'}
-		self.rubrik_api_user = app.config['RUBRIK_API_USER']
-		self.rubrik_api_pass = app.config['RUBRIK_API_PASS']
+		self.rubrik_api_user = helper.config['RUBRIK_API_USER']
+		self.rubrik_api_pass = helper.config['RUBRIK_API_PASS']
 		self.get_api_token()
 
 	def get_api_token(self):
@@ -82,7 +80,7 @@ class Rubrik(object):
 	def get_vm_managed_id(self, system):
 		"""Works out the Rubrik Managed ID of a VM"""
 
-		# Format of Rurrik Managed ID is:
+		# Format of Rubrik Managed ID is:
 		# VirtualMachine:::<vcenter-rubrik-managed-id>-<vm-moId>
 
 		if 'vmware_vcenter' not in system or 'vmware_moid' not in system:
@@ -107,14 +105,14 @@ class Rubrik(object):
 			vm_id = self.get_vm_managed_id(system)
 		except Exception as e:
 			import traceback
-			app.logger.error('Error getting Rubrik VM ID:\n' + traceback.format_exc())
+			self.helper.logger.error('Error getting Rubrik VM ID:\n' + traceback.format_exc())
 			raise Exception('Error getting Rubrik VM ID: ' + str(e))
 
 		try:
 			return self.get_request('vmware/vm/' + quote(vm_id))
 		except Exception as e:
 			import traceback
-			app.logger.error('Error getting Rubrik VM ID:\n' + traceback.format_exc())
+			self.helper.logger.error('Error getting Rubrik VM ID:\n' + traceback.format_exc())
 			raise Exception('Error getting VM from Rubrik: ' + str(e))
 
 	def get_vm_snapshots(self, id):

--- a/neocortex/TaskHelper.py
+++ b/neocortex/TaskHelper.py
@@ -13,6 +13,29 @@ import time
 from setproctitle import setproctitle #pip install setproctitle
 from corpus import Corpus
 
+class TaskHelperLogger(object):
+	"""This is a Python-logging-like object that is used by TaskHelper, so that
+	certain classes don't need to care whether they get an "app" object or a
+	TaskHelper object if they only need logger and config."""
+
+	def log(self, lvl, msg, *args, **kwargs):
+		print(str(lvl) + ": " + str(msg).format(args), file=sys.stderr)
+
+	def debug(self, msg, *args, **kwargs):
+		self.log('DEBUG', msg, *args, **kwargs)
+
+	def info(self, msg, *args, **kwargs):
+		self.log('INFO', msg, *args, **kwargs)
+
+	def error(self, msg, *args, **kwargs):
+		self.log('ERROR', msg, *args, **kwargs)
+
+	def warning(self, msg, *args, **kwargs):
+		self.log('WARNING', msg, *args, **kwargs)
+
+	def critical(self, msg, *args, **kwargs):
+		self.log('CRITICAL', msg, *args, **kwargs)
+
 class TaskHelper(object):
 
 	# Task / Event statuses
@@ -39,6 +62,7 @@ class TaskHelper(object):
 		self.username       = username
 		self.event_id       = -1
 		self.event_problems = 0
+		self.logger         = TaskHelperLogger()
 
 	def _signal_handler(self, signal, frame):
 		"""Marks task and event as failed when interrupted by a signal, and then exits"""

--- a/neocortex/rubrik_crcheck.py
+++ b/neocortex/rubrik_crcheck.py
@@ -39,10 +39,13 @@ def run(helper, options):
 		vm_link = '{{system_link id="' + str(cortex_vm_data['id']) + '"}}' + cortex_vm_data['name'] + '{{/system_link}}'
 
 		# retrieving the info that Rubrik has on the device
-		rubrik_vm_data = rubrik_connection.get_vm(cortex_vm_data)
+		try:
+			rubrik_vm_data = rubrik_connection.get_vm(cortex_vm_data)
+		except Exception as e:
+			rubrik_vm_data = None
 		
 		# If Rubrik doesn't have any data on it, there's nothing we can do. This should NOT happen though - it's possibly pointing to user error
-		if rubrik_vm_data == None:
+		if rubrik_vm_data is None:
 			helper.event("_rubrik_unknown", vm_link + ' does not exist in Rubrik', oneshot=True, success=False, warning=True)
 
 		# If Cortex is set to backup but Rubrik isn't, update the Rubrik to the default for the box's environment


### PR DESCRIPTION
Fixed an issue where VMs that hadn't made it in to Rubrik yet were causing exceptions during the Rubrik policy check. This also highlighted an issue regardling logging in the corpus.Rubrik class, which is fixed by making TaskHelper and app look more similar by making TaskHelper provide a logger variable that is a cut-down version of app.logger