### PR TITLE
Added decode_responses=True to StrictRedis

### DIFF
--- a/corpus/corpus.py
+++ b/corpus/corpus.py
@@ -1546,7 +1546,7 @@ class Corpus(object):
 		"""Connects to the Redis instance specified in the configuration and 
 		returns a StrictRedis object"""
 
-		return redis.StrictRedis(host=self.config['REDIS_HOST'], port=self.config['REDIS_PORT'], db=0)
+		return redis.StrictRedis(host=self.config['REDIS_HOST'], port=self.config['REDIS_PORT'], db=0, decode_responses=True)
 
 	################################################################################
 

--- a/request.py
+++ b/request.py
@@ -22,7 +22,7 @@ def before_request():
 
 	# Connect to redis
 	try:
-		g.redis = redis.StrictRedis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=0)
+		g.redis = redis.StrictRedis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=0, decode_responses=True)
 		g.redis.get('foo') # it doesnt matter that this key doesnt exist, its just to force a test call to redis.
 	except Exception as ex:
 		logerr()
@@ -149,21 +149,21 @@ def context_processor():
 
 		# Determine the layout mode for the user
 		try:
-			if str(g.redis.get('user:' + session['username'] + ":preferences:interface:layout"), 'utf-8') == "classic":
+			if g.redis.get('user:' + session['username'] + ":preferences:interface:layout") == "classic":
 				injectdata['classic_layout'] = True
 		except Exception as ex:
 			pass
 
 		# Determine theme for the user
 		try:
-			if str(g.redis.get('user:' + session['username'] + ":preferences:interface:theme"), 'utf-8') == "dark":
+			if g.redis.get('user:' + session['username'] + ":preferences:interface:theme") == "dark":
 				injectdata['theme'] = "dark"
 		except Exception as ex:
 			pass
 
 		# Determine whether to expand sidebar.
 		try:
-			if str(g.redis.get('user:' + session['username'] + ':preferences:interface:sidebar'), 'utf-8') == 'expand':
+			if g.redis.get('user:' + session['username'] + ':preferences:interface:sidebar')== 'expand':
 				injectdata['sidebar_expand'] = True
 		except Exception as ex:
 			pass

--- a/views/register.py
+++ b/views/register.py
@@ -151,14 +151,15 @@ def api_register_system():
 	if not interactive:
 		cdata['hostname']  = system['name']
 		cdata['fqdn']      = fqdn
-		netaddr = str(g.redis.get('vm/' + system['vmware_uuid'].lower() + '/ipaddress'), 'utf-8')
-		netaddrv6 = str(g.redis.get('vm/' + system['vmware_uuid'].lower() + '/ipv6address'), 'utf-8')
-		if netaddr == None:
-			cdata['ipaddress'] = 'dhcp'
-		else:
+		netaddr = g.redis.get('vm/' + system['vmware_uuid'].lower() + '/ipaddress')
+		netaddrv6 = g.redis.get('vm/' + system['vmware_uuid'].lower() + '/ipv6address')
+		
+		if netaddr:
 			cdata['ipaddress'] = netaddr
+		else:
+			cdata['ipaddress'] = 'dhcp'
 
-		if netaddrv6 is not None:
+		if netaddrv6:
 			cdata['ipv6address'] = netaddrv6
 
 		# Mark as done

--- a/workflows/certmgr/views.py
+++ b/workflows/certmgr/views.py
@@ -50,10 +50,10 @@ def get_certificate_from_redis(task):
 	prefix = 'certmgr/' + str(task['id']) + '/'
 
 	if g.redis.exists(prefix + 'certificate') and g.redis.exists(prefix + 'private'):
-		pem_cert = g.redis.get(prefix + 'certificate').decode('utf-8')
-		pem_key = g.redis.get(prefix + 'private').decode('utf-8')
+		pem_cert = g.redis.get(prefix + 'certificate')
+		pem_key = g.redis.get(prefix + 'private')
 		if g.redis.exists(prefix + 'chain'):
-			pem_chain = g.redis.get(prefix + 'chain').decode('utf-8')
+			pem_chain = g.redis.get(prefix + 'chain')
 
 	return (pem_cert, pem_key, pem_chain)
 

--- a/workflows/decom/views.py
+++ b/workflows/decom/views.py
@@ -29,12 +29,12 @@ def get_system_actions_from_redis(task):
 	prefix = 'decom/' +  str(task['id']) + '/'
 
 	if g.redis.exists(prefix + 'actions') and g.redis.exists(prefix + 'system'):
-		signed_actions = str(g.redis.get(prefix + 'actions'),'utf-8')
-		system_id = str(g.redis.get(prefix + 'system'), 'utf-8')
+		signed_actions = g.redis.get(prefix + 'actions')
+		system_id = g.redis.get(prefix + 'system')
 	else:
 		raise RuntimeError("Required keys don't exist in Redis. You must complete a decommission within an hour of starting it.")
 
-	if signed_actions is not None:
+	if signed_actions:
 		# Decode the Signed Actions / System Data. 
 		signer = JSONWebSignatureSerializer(app.config['SECRET_KEY'])
 		try:


### PR DESCRIPTION
This fixes problems where we've wrapped a .get('key') in a str() to decode it, but the key does not exist thus .get returns None.